### PR TITLE
Clarify who is who for Wikipedia

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,9 +137,9 @@
 				</div>
 				<div class="col-md-5 col-md-push-1 col-sm-6">
 					<h2 class="space-before">Why should I use it?</br> <span class="text-muted">What's it's purpose?</span></h2>
-					<p>Using WikipediaP2P helps Wikipedia Foundation to save bandwidth and resources, and improves the experience from places where many Wikipedia users are in the same local network (Universities, Schools or even complete countries).</p>
-					<p>This is an <b>unofficial extension</b> and not entitled by Wikipedia in any way, it's just an implementation of latest web-technologies towards sharing of knowelege.</p>
-					<p>It's <b>Open Source</b>, Hopefully Wikipedia could see this project and consider implementing it officially.</p>
+					<p>Using WikipediaP2P helps Wikimedia Foundation to save bandwidth and resources, and improves the experience from places where many Wikipedia users are in the same local network (Universities, Schools or even complete countries).</p>
+					<p>This is an <b>unofficial extension</b> and not maintained by the project in any way, it's just an implementation of latest web-technologies towards sharing of knowelege.</p>
+					<p>It's <b>Open Source</b>, Hopefully Wikipedia folks could see this project and consider implementing it officially.</p>
 					</br>
 
 				</div>


### PR DESCRIPTION
There is a small typo in the org name: Wikipedia Foundation → Wikimedia Foundation.

As Wikimedia Foundation hosts and maintains the server, but doesn't represent
each Wikipedia contributors, so the next sentences are more complicated to fix.

A good approach is to say any person involved as Wikipedia contributor could
raise awareness on the existence of WikipediaP2P and push the issue forward.